### PR TITLE
Split paragraphs containing (Forts.) via regex

### DIFF
--- a/src/add_uuid.py
+++ b/src/add_uuid.py
@@ -9,6 +9,10 @@ from pyriksdagen.utils import elem_iter, protocol_iterators, get_formatted_uuid
 from pyriksdagen.utils import TEI_NS, XML_NS
 from tqdm import tqdm
 import multiprocessing
+from pyriksdagen.args import (
+    fetch_parser,
+    impute_args,
+)
 
 def add_protocol_id(protocol):
     ids = set()
@@ -69,7 +73,7 @@ def add_protocol_id(protocol):
 
 
 def main(args):
-    protocols = sorted(list(protocol_iterators(args.records_folder, start=args.start, end=args.end)))
+    protocols = args.records
     num_ids = 0
     ids = []
     with multiprocessing.Pool() as pool:
@@ -81,9 +85,6 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--records_folder", type=str, default="corpus/records")
-    parser.add_argument("-s", "--start", type=int, default=None, help="Start year")
-    parser.add_argument("-e", "--end", type=int, default=None, help="End year")
-    args = parser.parse_args()
+    parser = fetch_parser("records")
+    args = impute_args(parser.parse_args())
     main(args)

--- a/src/cur-prot/classify_intros.py
+++ b/src/cur-prot/classify_intros.py
@@ -4,7 +4,7 @@ Find  introductions in the protocols using BERT. Used in tandem with resegment.p
 import pandas as pd
 from lxml import etree
 from transformers import AutoModelForSequenceClassification, BertTokenizerFast
-from pyriksdagen.utils import protocol_iterators, elem_iter, get_data_location
+from pyriksdagen.utils import protocol_iterators, elem_iter, get_data_location, TEI_NS
 import torch
 from tqdm import tqdm
 from torch.utils.data import DataLoader
@@ -17,19 +17,36 @@ from pyriksdagen.args import (
     impute_args,
 )
 
+def extract_elem_jointly(protocol, elem):
+    text = elem.text.split()
+    text = " ".join(text)
+    u = elem.tag[-1] == "u"
+    intro = elem.attrib.get("type") == "speaker"
+
+    if intro:
+        if elem.getnext().tag == f"{TEI_NS}u":
+            print(f"concat intro ({text}) with next seg")
+            text = text + " " + " ".join(elem.getnext()[0].text.split())
+            print(f"result: {text}")
+
+    return text, elem.get("{http://www.w3.org/XML/1998/namespace}id"), protocol
+
 def extract_elem(protocol, elem):
     return elem.text, elem.get("{http://www.w3.org/XML/1998/namespace}id"), protocol
 
 
-def extract_note_seg(protocol):
+def extract_note_seg(protocol, heuristic=False):
     parser = etree.XMLParser(remove_blank_text=True)
     root = etree.parse(protocol, parser).getroot()
     data = []
+    extract_elem_fun = extract_elem
+    if heuristic:
+        extract_elem_fun = extract_elem_jointly
     for tag, elem in elem_iter(root):
         if tag == 'note':
-            data.append(extract_elem(protocol, elem))
+            data.append(extract_elem_fun(protocol, elem))
         elif tag == 'u':
-            data.extend(list(map(partial(extract_elem, protocol), elem)))
+            data.extend(list(map(partial(extract_elem_fun, protocol), elem)))
     return data
 
 
@@ -71,7 +88,7 @@ def main(args):
         files = protocol_df.loc[protocol_df['folder'] == folder, 'file'].tolist()
         data = []
         for file in tqdm(files, total=len(files)):
-            data.extend(extract_note_seg(os.path.join(folder, file)))
+            data.extend(extract_note_seg(os.path.join(folder, file), heuristic=args.join_heuristic))
         df = pd.DataFrame(data, columns=['text', 'id', 'file_path'])
         print(df)
         df = predict_intro(df, cuda=args.cuda)
@@ -86,6 +103,7 @@ def main(args):
 if __name__ == "__main__":
     parser = fetch_parser("records")
     parser.add_argument("--cuda", action="store_true", help="Set this flag to run with cuda.")
+    parser.add_argument("--join_heuristic", action="store_true", help="Jointly predict intros that have been previously split")
     parser.add_argument("--outpath", default="input/segmentation/intros.csv")
     args = impute_args(parser.parse_args())
     main(args)

--- a/src/cur-prot/classify_intros.py
+++ b/src/cur-prot/classify_intros.py
@@ -12,7 +12,10 @@ import argparse
 from pyriksdagen.dataset import IntroDataset
 from functools import partial
 import os
-
+from pyriksdagen.args import (
+    fetch_parser,
+    impute_args,
+)
 
 def extract_elem(protocol, elem):
     return elem.text, elem.get("{http://www.w3.org/XML/1998/namespace}id"), protocol
@@ -58,53 +61,31 @@ def predict_intro(df, cuda):
 
 def main(args):
     intros = []
-    if args.protocol:
-        df = pd.DataFrame(
-            extract_note_seg(args.protocol),
-            columns=['text', 'id', 'file_path'])
-        df = predict_intro(df, cuda=args.cuda)
+    protocols = args.records
+    protocols = [os.path.split(p) for p in protocols]
+    protocol_df = pd.DataFrame(protocols, columns=['folder', 'file'])
+    protocol_df = protocol_df.sort_values(by=['folder', 'file'])
+    folders = sorted(set(protocol_df['folder']))
+
+    for folder in folders:
+        files = protocol_df.loc[protocol_df['folder'] == folder, 'file'].tolist()
+        data = []
+        for file in tqdm(files, total=len(files)):
+            data.extend(extract_note_seg(os.path.join(folder, file)))
+        df = pd.DataFrame(data, columns=['text', 'id', 'file_path'])
         print(df)
-    else:
-        # Create folder iterator for reasonably large batches
-        if args.records_folder is not None:
-            data_location = args.records_folder
-        else:
-            data_location = get_data_location("records")
-        protocols = protocol_iterators(data_location, start=args.start, end=args.end)
-        protocols = [os.path.split(p) for p in protocols]
-        protocol_df = pd.DataFrame(protocols, columns=['folder', 'file'])
-        protocol_df = protocol_df.sort_values(by=['folder', 'file'])
-        folders = sorted(set(protocol_df['folder']))
+        df = predict_intro(df, cuda=args.cuda)
+        intros.append(df)
 
-        for folder in folders:
-            files = protocol_df.loc[protocol_df['folder'] == folder, 'file'].tolist()
-            data = []
-            for file in tqdm(files, total=len(files)):
-                data.extend(extract_note_seg(os.path.join(folder, file)))
-            df = pd.DataFrame(data, columns=['text', 'id', 'file_path'])
-            print(df)
-            df = predict_intro(df, cuda=args.cuda)
-            intros.append(df)
-
-        df = pd.concat(intros)
+    df = pd.concat(intros)
     df.to_csv(args.outpath, index=False)
 
 
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("-s", "--start", type=int, default=1920, help="Start year")
-    parser.add_argument("-e", "--end", type=int, default=2022, help="End year")
-    parser.add_argument("-r", "--records-folder",
-                        type=str,
-                        default=None,
-                        help="(optional) Path to records folder, defaults to environment var or `data/`")
-    parser.add_argument("-p", "--protocol",
-                    type=str,
-                    default=None,
-                    help="operate on a single protocol")
+    parser = fetch_parser("records")
     parser.add_argument("--cuda", action="store_true", help="Set this flag to run with cuda.")
     parser.add_argument("--outpath", default="input/segmentation/intros.csv")
-    args = parser.parse_args()
+    args = impute_args(parser.parse_args())
     main(args)

--- a/src/cur-prot/classify_intros.py
+++ b/src/cur-prot/classify_intros.py
@@ -24,10 +24,14 @@ def extract_elem_jointly(protocol, elem):
     intro = elem.attrib.get("type") == "speaker"
 
     if intro:
-        if elem.getnext().tag == f"{TEI_NS}u":
-            print(f"concat intro ({text}) with next seg")
-            text = text + " " + " ".join(elem.getnext()[0].text.split())
-            print(f"result: {text}")
+        next_elem = elem.getnext()
+        if next_elem.tag == f"{TEI_NS}u":
+            if next_elem.text is not None:
+                print(f"concat intro ({text}) with next seg")
+                u_text = " ".join(elem.getnext()[0].text.split())
+                #u_text = u_text.split(".")[0]
+                text = text + " " + u_text
+                print(f"result: {text}")
 
     return text, elem.get("{http://www.w3.org/XML/1998/namespace}id"), protocol
 
@@ -91,6 +95,13 @@ def main(args):
             data.extend(extract_note_seg(os.path.join(folder, file), heuristic=args.join_heuristic))
         df = pd.DataFrame(data, columns=['text', 'id', 'file_path'])
         print(df)
+        N = len(df)
+        null_data = df[df.isnull().any(axis=1)]
+        df = df.dropna()
+        N_prime = len(df)
+        if N != N_prime:
+            print(f"{N - N_prime} null rows were omitted.")
+            print(null_data)
         df = predict_intro(df, cuda=args.cuda)
         intros.append(df)
 

--- a/src/cur-prot/classify_intros.py
+++ b/src/cur-prot/classify_intros.py
@@ -26,12 +26,14 @@ def extract_elem_jointly(protocol, elem):
     if intro:
         next_elem = elem.getnext()
         if next_elem.tag == f"{TEI_NS}u":
+            next_elem = next_elem[0]
             if next_elem.text is not None:
                 print(f"concat intro ({text}) with next seg")
-                u_text = " ".join(elem.getnext()[0].text.split())
-                #u_text = u_text.split(".")[0]
+                u_text = " ".join(next_elem.text.split())
+                #if "." in u_text:
+                #    u_text = u_text.split(".")[0] + "."
                 text = text + " " + u_text
-                print(f"result: {text}")
+                #print(f"result: {text}")
 
     return text, elem.get("{http://www.w3.org/XML/1998/namespace}id"), protocol
 

--- a/src/cur-prot/redetect.py
+++ b/src/cur-prot/redetect.py
@@ -9,7 +9,10 @@ from pyriksdagen.utils import protocol_iterators, get_data_location
 from tqdm import tqdm
 from multiprocessing import Pool
 from functools import partial
-
+from pyriksdagen.args import (
+    fetch_parser,
+    impute_args,
+)
 
 
 
@@ -59,24 +62,12 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
-
-
-    parser.add_argument("-s", "--start", type=int, default=1867, help="Start year")
-    parser.add_argument("-e", "--end", type=int, default=2022, help="End year")
-    parser.add_argument("-r", "--records-folder",
-                        type=str,
-                        default=None,
-                        help="(optional) Path to records folder, defaults to environment var or `data/`")
+    parser = fetch_parser("records")
     parser.add_argument("-m", "--metadata-root",
                         type=str,
                         default=None,
                         help="(optional) Path to metadata root folder, defaults to environment var or `data/`")
-    parser.add_argument("-p", "--protocol",
-                        type=str,
-                        default=None,
-                        help="operate on a single protocol")
     parser.add_argument("--parallel", type=int, default=1, help="N parallel processes (default=1)")
     parser.add_argument("--processed-metadata-folder", type=str, default="input/matching")
-    args = parser.parse_args()
+    args = impute_args(parser.parse_args())
     main(args)

--- a/src/cur-prot/resegment.py
+++ b/src/cur-prot/resegment.py
@@ -16,6 +16,10 @@ from pyriksdagen.utils import (
     protocol_iterators,
     write_protocol,
 )
+from pyriksdagen.args import (
+    fetch_parser,
+    impute_args,
+)
 from lxml import etree
 import pandas as pd
 import os, progressbar, argparse
@@ -24,17 +28,7 @@ import os, progressbar, argparse
 
 
 def main(args):
-    if args.protocol:
-        protocols = [args.protocol]
-    else:
-        if args.records_folder is not None:
-            data_location = args.records_folder
-        else:
-            data_location = get_data_location("records")
-        protocols = list(protocol_iterators(data_location,
-                                            start=args.start,
-                                            end=args.end))
-
+    protocols = args.records
     intro_df = pd.read_csv(args.segmentation_file)
 
     for protocol in progressbar.progressbar(protocols):
@@ -68,19 +62,9 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = fetch_parser("records")
     parser.add_argument("--segmentation_file",
                         type=str,
                         default="input/segmentation/intros.csv")
-    parser.add_argument("-s", "--start", type=int, default=1920, help="Start year")
-    parser.add_argument("-e", "--end", type=int, default=2022, help="End year")
-    parser.add_argument("-r", "--records-folder",
-                        type=str,
-                        default=None,
-                        help="(optional) Path to records folder, defaults to environment var or `data/`")
-    parser.add_argument("-p", "--protocol",
-                        type=str,
-                        default=None,
-                        help="operate on a single protocol")
-    args = parser.parse_args()
+    args = impute_args(parser.parse_args())
     main(args)

--- a/src/cur-prot/resegment.py
+++ b/src/cur-prot/resegment.py
@@ -54,7 +54,7 @@ def main(args):
         pattern_db = pattern_db[
             (pattern_db["start"] <= year) & (pattern_db["end"] >= year)
         ]
-        root = find_introductions(root, pattern_db, intro_ids, minister_db=None)
+        root = find_introductions(root, pattern_db, intro_ids, minister_db=None, remove_missing=args.remove_negative)
 
         write_protocol(root, protocol)
 
@@ -66,5 +66,7 @@ if __name__ == "__main__":
     parser.add_argument("--segmentation_file",
                         type=str,
                         default="input/segmentation/intros.csv")
+    parser.add_argument("--remove_negative", action="store_true",
+                        help="Also remove previously detected 'speaker' attributes. By default only finds new intros.")
     args = impute_args(parser.parse_args())
     main(args)

--- a/src/cur-prot/split_forts.py
+++ b/src/cur-prot/split_forts.py
@@ -25,7 +25,7 @@ def split_text(t, pattern):
     p1, p2 = pattern.split()
     return s[0] + p1, p2 + s[1]
 
-def find_forts(root):
+def forts_herr(root):
     #re.compile("\\(Forts.\\) Herr [] \\:")
     pattern = "(Forts.) Herr"
     for tag, elem in elem_iter(root):
@@ -53,20 +53,54 @@ def find_forts(root):
     return root
 
 
+def ang_forts(root):
+
+    exp = re.compile(r"Ang\. [\w ]{10,40}(.) \((f|F)orts(\.)\) ")
+    #re.compile("\\(Forts.\\) Herr [] \\:")
+    
+    for tag, elem in elem_iter(root):
+        if tag == "u":
+            for seg in elem:
+                if seg.text is not None:
+                    elemtext = " ".join(seg.text.split())
+                    if exp.match(elemtext) is not None:
+                        matched_str = exp.match(elemtext).group(0)
+                        if len(matched_str) * 1.05 < len(elemtext.strip()):
+
+                            if elemtext.strip()[:4] == "Ang.":
+                                elemtext = elemtext.replace(matched_str, "")
+                                seg.text = matched_str
+                                newchild = etree.Element(f"{TEI_NS}seg")
+                                newchild.text = elemtext
+                                seg.addnext(newchild)
+        elif tag == "note":
+            if elem.text is not None:
+                elemtext = " ".join(elem.text.split())
+                if exp.match(elemtext) is not None:
+                    matched_str = exp.match(elemtext).group(0)
+                    if len(matched_str) * 1.05 < len(elemtext.strip()):
+
+                        if elemtext.strip()[:4] == "Ang.":
+                            elemtext = elemtext.replace(matched_str, "")
+                            elem.text = matched_str
+                            newchild = etree.Element(f"{TEI_NS}note")
+                            newchild.text = elemtext
+                            elem.addnext(newchild)
+
+    return root
+
 
 def main(args):
-    print(args.records)
     for protocol in tqdm(args.records):
         root, _ = parse_tei(protocol)
-        print(root)
-        root = find_forts(root)
+        if args.pattern == "forts-herr":
+            root = forts_herr(root)
+        else:
+            root = ang_forts(root)
         write_protocol(root, protocol)
-
-
 
 
 if __name__ == "__main__":
     parser = fetch_parser("records")
-    parser.add_argument("--json_path", type=str, default=[], nargs="+")
-    parser.add_argument("--skip-doctors-notes", action='store_true')
+    parser.add_argument("--pattern", type=str, default="forts-herr", choices=['forts-herr', 'ang-forts'])
     main(impute_args(parser.parse_args()))

--- a/src/cur-prot/split_forts.py
+++ b/src/cur-prot/split_forts.py
@@ -1,0 +1,72 @@
+"""
+Fix a common segmentation error: margin notes ending in '(Forts.)' are merged into the text body
+"""
+from lxml import etree
+from pyriksdagen.utils import (
+    get_data_location,
+    parse_tei,
+    protocol_iterators,
+    write_protocol,
+    TEI_NS,
+    XML_NS,
+    elem_iter
+)
+from tqdm import tqdm
+import argparse
+import re
+from pyriksdagen.args import (
+    fetch_parser,
+    impute_args,
+)
+
+
+def split_text(t, pattern):
+    s = t.split(pattern)
+    p1, p2 = pattern.split()
+    return s[0] + p1, p2 + s[1]
+
+def find_forts(root):
+    #re.compile("\\(Forts.\\) Herr [] \\:")
+    pattern = "(Forts.) Herr"
+    for tag, elem in elem_iter(root):
+        #if tag == "u":
+        #    for seg in elem:
+        #        if seg.text is not None:
+        #            elemtext = " ".join(seg.text.split())
+        #            if pattern in elemtext:
+        #                #print(elemtext)
+        #                t1, t2 = split_text(elemtext, pattern)
+        #                seg.text = t1
+
+        if tag == "note":
+            if elem.text is not None:
+                elemtext = " ".join(elem.text.split())
+                if pattern in elemtext:
+                    #print(elemtext)
+                    t1, t2 = split_text(elemtext, pattern)
+                    elem.text = t1
+                    newchild = etree.Element(f"{TEI_NS}note")
+                    newchild.text = t2
+                    elem.addnext(newchild)
+
+
+    return root
+
+
+
+def main(args):
+    print(args.records)
+    for protocol in tqdm(args.records):
+        root, _ = parse_tei(protocol)
+        print(root)
+        root = find_forts(root)
+        write_protocol(root, protocol)
+
+
+
+
+if __name__ == "__main__":
+    parser = fetch_parser("records")
+    parser.add_argument("--json_path", type=str, default=[], nargs="+")
+    parser.add_argument("--skip-doctors-notes", action='store_true')
+    main(impute_args(parser.parse_args()))

--- a/src/cur-prot/split_forts.py
+++ b/src/cur-prot/split_forts.py
@@ -47,6 +47,10 @@ def forts_herr(root):
                     elem.text = t1
                     newchild = etree.Element(f"{TEI_NS}note")
                     newchild.text = t2
+
+                    if elem.attrib.get("type") == "speaker":
+                        newchild.attrib["type"] = "speaker"
+                        del elem.attrib["type"]
                     elem.addnext(newchild)
 
 


### PR DESCRIPTION
I wrote two patterns:
1. "(Forts.) Herr" will be always split into two
2. A regex matching roughly "Ang. [...] (Forts.)" in the beginning of any paragraph will be moved to its own element

The pull request is about the first pattern. The second seems to work well too, but I didn't create a sample yet.

In addition to this, I
- Refactored some scripts to use the new argparse function
- Implemented a heuristic to improve intro classification. It uses text from the next <u> element for each elem currently classified as an intro. Related to https://github.com/swerik-project/bert-riksdagen-classifier/issues/2