### PR TITLE
fix: [records] generate speech IDs according to the decision

### DIFF
--- a/src/cur-prot/annotate-speeches.py
+++ b/src/cur-prot/annotate-speeches.py
@@ -37,7 +37,7 @@ def find_speeches(root, ns):
         Generate a deterministic speech ID and add to the dict.
 
         The ID is generated from a deterministic seed, which
-        consists of "speed" + the ID of the speaker introduction
+        consists of "speech" + the ID of the speaker introduction
         before + the ID of the speaker introduction after. If no
         speaker introduction is found after due to the div
         changing, "div" is added instead. If no introduction is

--- a/src/cur-prot/annotate-speeches.py
+++ b/src/cur-prot/annotate-speeches.py
@@ -33,6 +33,17 @@ def find_speeches(root, ns):
     prev_intro_id, current_intro_id = None, None
     passed_intro = False
     def add_to_speeches(speeches, speech_elems, id1, id2):
+        """
+        Generate a deterministic speech ID and add to the dict.
+
+        The ID is generated from a deterministic seed, which
+        consists of "speed" + the ID of the speaker introduction
+        before + the ID of the speaker introduction after. If no
+        speaker introduction is found after due to the div
+        changing, "div" is added instead. If no introduction is
+        found due to the document ending, nothing is added at the
+        end.
+        """
         seed = "speech" + id1
         if id2 is not None:
             seed += id2

--- a/src/cur-prot/annotate-speeches.py
+++ b/src/cur-prot/annotate-speeches.py
@@ -91,7 +91,7 @@ def find_speeches(root, ns, record):
     return speeches
 
 
-def add_speeches_to_metadata(speeches, root, ns):
+def add_speeches_to_metadata(speeches, root, ns, perserve_constitution):
     """
     Add speeches and text-containing sub elements to the TEIHeader
     under the constitution element.
@@ -118,6 +118,10 @@ def add_speeches_to_metadata(speeches, root, ns):
         if composition is None:
             logger.debug("Creating composition elem")
             composition = etree.SubElement(textDesc, "composition")
+    else:
+        if not preserve_constitution:
+            for child in list(constitution):
+                constitution.remove(child)
 
     if composition is None:
         textDesc = teiHeader.find(f".//{ns['tei_ns']}textDesc")
@@ -146,7 +150,7 @@ def main(args):
         speeches = find_speeches(root, ns, record)
         if len(speeches) > 0:
             logger.debug(f"  {len(speeches)} speeches found")
-            if add_speeches_to_metadata(speeches, root, ns):
+            if add_speeches_to_metadata(speeches, root, ns, args.preserve_constitution):
                 write_tei(root, record)
             else:
                 logger.critical("Problem adding speeches to meatadata")
@@ -158,4 +162,7 @@ def main(args):
 
 if __name__ == '__main__':
     parser = fetch_parser("records", docstring=__doc__)
+    parser.add_argument("--preserve-constitution",
+                        action='store_true',
+                        help="Don't clobber the constitution element")
     main(impute_args(parser.parse_args()))

--- a/src/cur-prot/annotate-speeches.py
+++ b/src/cur-prot/annotate-speeches.py
@@ -27,7 +27,7 @@ logger = get_logger(name="Annotate Speeches")
 
 
 
-def find_speeches(root, ns):
+def find_speeches(root, ns, record):
     speeches = {}
     speech_elems = []
     prev_intro_id, current_intro_id = None, None
@@ -54,8 +54,13 @@ def find_speeches(root, ns):
 
     TEI_NS = ns['tei_ns']
     body = root.findall(f".//{TEI_NS}body")
-    assert len(body) == 1, f"bodies found {body}"
-    body = body[0]
+    if not len(body) == 1:
+        logger.error(f"Body elem != 1 in {record} | Body elems: {body}")
+
+    try:
+        body = body[0]
+    except:
+        return speeches
     for elem in body.iter():
         # Remove namespace from the tag
         tag = elem.tag.split("}")[-1]
@@ -134,7 +139,7 @@ def main(args):
     for record in tqdm(args.records):
         logger.debug(record)
         root, ns = parse_tei(record)
-        speeches = find_speeches(root, ns)
+        speeches = find_speeches(root, ns, record)
         if len(speeches) > 0:
             logger.debug(f"  {len(speeches)} speeches found")
             if add_speeches_to_metadata(speeches, root, ns):

--- a/src/cur-prot/annotate-speeches.py
+++ b/src/cur-prot/annotate-speeches.py
@@ -92,6 +92,10 @@ def find_speeches(root, ns, record):
 
 
 def add_speeches_to_metadata(speeches, root, ns):
+    """
+    Add speeches and text-containing sub elements to the TEIHeader
+    under the constitution element.
+    """
     teiHeader = root.find(f"{ns['tei_ns']}teiHeader")
     if teiHeader is None:
         raise ValueError(f"No TEI header found")

--- a/src/cur-prot/annotate-speeches.py
+++ b/src/cur-prot/annotate-speeches.py
@@ -46,15 +46,16 @@ def find_speeches(root, ns):
     assert len(body) == 1, f"bodies found {body}"
     body = body[0]
     for elem in body.iter():
-        tag = elem.tag
-        if "div" == tag[-3:]:
+        # Remove namespace from the tag
+        tag = elem.tag.split("}")[-1]
+        if "div" == tag:
             if len(speech_elems) > 0:
                 speeches = add_to_speeches(speeches, speech_elems, current_intro_id, "div")
                 speech_elems = []
             prev_intro_id, current_intro_id = None, None
             passed_intro = False
 
-        elif tag[-4:] == "note" and elem.attrib.get("type") == "speaker":
+        elif tag == "note" and elem.attrib.get("type") == "speaker":
             #print("passed intro")
             passed_intro = True
 
@@ -63,7 +64,7 @@ def find_speeches(root, ns):
             if len(speech_elems) > 0:
                 speeches = add_to_speeches(speeches, speech_elems, prev_intro_id, current_intro_id)
                 speech_elems = []
-        elif tag[-1] == "u" and passed_intro:
+        elif tag == "u" and passed_intro:
             speech_elems.append(elem.get(f"{ns['xml_ns']}id"))
 
     if len(speech_elems) > 0:

--- a/src/cur-prot/annotate-speeches.py
+++ b/src/cur-prot/annotate-speeches.py
@@ -57,6 +57,8 @@ def add_speeches_to_metadata(speeches, root, ns):
     teiHeader = root.find(f"{ns['tei_ns']}teiHeader")
     if teiHeader is None:
         raise ValueError(f"No TEI header found")
+
+    composition = None
     constitution = teiHeader.find(f".//{ns['tei_ns']}constitution")
     if constitution is None:
         logger.debug("constitution element not found.")
@@ -74,6 +76,12 @@ def add_speeches_to_metadata(speeches, root, ns):
         if composition is None:
             logger.debug("Creating composition elem")
             composition = etree.SubElement(textDesc, "composition")
+
+    if composition is None:
+        textDesc = teiHeader.find(f".//{ns['tei_ns']}textDesc")
+        composition = textDesc.find(f".//{ns['tei_ns']}constitution")
+        for note in list(composition):
+            composition.remove(note)
 
     for id_, Us in speeches.items():
         speechNote = etree.SubElement(composition, "note")

--- a/src/cur-prot/annotate-speeches.py
+++ b/src/cur-prot/annotate-speeches.py
@@ -91,7 +91,7 @@ def find_speeches(root, ns, record):
     return speeches
 
 
-def add_speeches_to_metadata(speeches, root, ns, perserve_constitution):
+def add_speeches_to_metadata(speeches, root, ns, preserve_constitution):
     """
     Add speeches and text-containing sub elements to the TEIHeader
     under the constitution element.

--- a/src/cur-prot/annotate-speeches.py
+++ b/src/cur-prot/annotate-speeches.py
@@ -30,23 +30,44 @@ logger = get_logger(name="Annotate Speeches")
 def find_speeches(root, ns):
     speeches = {}
     speech_elems = []
+    prev_intro_id, current_intro_id = None, None
     passed_intro = False
-    def add_to_speeches(speeches, speech_elems):
-        seed = ''.join(speech_elems)
+    def add_to_speeches(speeches, speech_elems, id1, id2):
+        seed = "speech" + id1
+        if id2 is not None:
+            seed += id2
+
         speech_ID = get_formatted_uuid(seed=seed)
         speeches[speech_ID] = speech_elems
         return speeches
-    for tag, elem in elem_iter(root):
-        if tag == "note" and elem.attrib.get("type") == "speaker":
+
+    TEI_NS = ns['tei_ns']
+    body = root.findall(f".//{TEI_NS}body")
+    assert len(body) == 1, f"bodies found {body}"
+    body = body[0]
+    for elem in body.iter():
+        tag = elem.tag
+        if "div" == tag[-3:]:
+            if len(speech_elems) > 0:
+                speeches = add_to_speeches(speeches, speech_elems, current_intro_id, "div")
+                speech_elems = []
+            prev_intro_id, current_intro_id = None, None
+            passed_intro = False
+
+        elif tag[-4:] == "note" and elem.attrib.get("type") == "speaker":
             #print("passed intro")
             passed_intro = True
+
+            prev_intro_id = current_intro_id
+            current_intro_id = elem.get(f"{ns['xml_ns']}id")
             if len(speech_elems) > 0:
-                speeches = add_to_speeches(speeches, speech_elems)
+                speeches = add_to_speeches(speeches, speech_elems, prev_intro_id, current_intro_id)
                 speech_elems = []
-        elif tag == "u" and passed_intro:
+        elif tag[-1] == "u" and passed_intro:
             speech_elems.append(elem.get(f"{ns['xml_ns']}id"))
+
     if len(speech_elems) > 0:
-        speeches = add_to_speeches(speeches, speech_elems)
+        speeches = add_to_speeches(speeches, speech_elems, current_intro_id, None)
 
     if not len(list(speeches.keys())) == len(list(set(list(speeches.keys())))):
         raise ValueError(f"You probably have a duplicate UUID,")


### PR DESCRIPTION
fix: generate speech IDs according to the decision.

Now the seed is the intro ID and the next intro ID, or div break or document end (see https://github.com/swerik-project/the-swedish-parliament-corpus/blob/main/docs/decisions/decision-7_add-constitution-elem-to-metadata.md). This is summarized in the docstring:

>Generate a deterministic speech ID and add to the dict.
>The ID is generated from a deterministic seed, which consists of "speech" + the ID of the speaker introduction before + the ID of the speaker introduction after. If no speaker introduction is found after due to the div changing, "div" is added instead. If no introduction is found due to the document ending, nothing is added at the end.

In addition to this, the treatment of the composition block is adjusted so that if it already exists, that won't crash the script.